### PR TITLE
adding readme message to tell about add/dockerfile branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This code base provides a flask-driven infrastructure to explore the myconnectom
 #### myConnectome-vm
 If you are interested in reproducing all analyses in your own virtual machine, it is recommended to follow instructions in the [myconnectome-vm repository](https://github.com/poldrack/myconnectome-vm). This vm will use myconnectome-explore to provide interactive exploration for the data that you produce. The installation is automatic and you do not need to do anything beyond following instructions to set up the virtual machine.
 
-If you are looking for a quick (non production) deployment container of the application,
-see the [poldracklab/myconnectome-explore](https://hub.docker.com/r/poldracklab/myconnectome-explore/) container served by the [add/dockerfile](https://github.com/vsoch/myconnectome-explore/tree/add/dockerfile) branch of this repository. This is a container that you can run locally to see
+If you are looking for a quick (non production) deployment (via a Docker container) of the application, see the [poldracklab/myconnectome-explore](https://hub.docker.com/r/poldracklab/myconnectome-explore/) container served by the [add/dockerfile](https://github.com/vsoch/myconnectome-explore/tree/add/dockerfile) branch of this repository. This is a container that you can run locally to see
 a single view of the interface (the interactive logs and progress pages are not relevant). 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This code base provides a flask-driven infrastructure to explore the myconnectom
 #### myConnectome-vm
 If you are interested in reproducing all analyses in your own virtual machine, it is recommended to follow instructions in the [myconnectome-vm repository](https://github.com/poldrack/myconnectome-vm). This vm will use myconnectome-explore to provide interactive exploration for the data that you produce. The installation is automatic and you do not need to do anything beyond following instructions to set up the virtual machine.
 
+If you are looking for a quick (non production) deployment container of the application,
+see the [poldracklab/myconnectome-explore](https://hub.docker.com/r/poldracklab/myconnectome-explore/) container served by the [add/dockerfile](https://github.com/vsoch/myconnectome-explore/tree/add/dockerfile) branch of this repository. This is a container that you can run locally to see
+the interface. If you want to see how the application is deployed in production,
+please see this master branch being cloned in the [myconnectome-vm Vagrantfile](https://github.com/poldrack/myconnectome-vm/blob/master/Vagrantfile#L76).
+
 ### standalone application
 You should first clone this repository
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ If you are interested in reproducing all analyses in your own virtual machine, i
 
 If you are looking for a quick (non production) deployment container of the application,
 see the [poldracklab/myconnectome-explore](https://hub.docker.com/r/poldracklab/myconnectome-explore/) container served by the [add/dockerfile](https://github.com/vsoch/myconnectome-explore/tree/add/dockerfile) branch of this repository. This is a container that you can run locally to see
-the interface. If you want to see how the application is deployed in production,
+a single view of the interface (the interactive logs and progress pages are not relevant). 
+
+```bash
+# Bind to port 80 to open at http://127.0.0.1
+docker run -p 80:5000 poldracklab/myconnectome-explore  
+
+# Bind to port 5000 to open at http://127.0.0.1:5000
+docker run -p 5000:5000 poldracklab/myconnectome-explore 
+```
+
+If you want to see how the application is deployed in production,
 please see this master branch being cloned in the [myconnectome-vm Vagrantfile](https://github.com/poldrack/myconnectome-vm/blob/master/Vagrantfile#L76).
 
 ### standalone application


### PR DESCRIPTION
This is a quick PR to alert the user about the `add/dockerfile` branch that serves the (static) version with the Dockerfile. There are no other substantial changes to this branch, as it is integrated into the myconnectome Vagrantfile and is a dependency of that.